### PR TITLE
fix two warning when compiling in g++7

### DIFF
--- a/core/core_include/api.h
+++ b/core/core_include/api.h
@@ -15,12 +15,12 @@ void do_assert(const char* file, int line);
 
 void log_out(const char* log);
 
-#define GLT_RGB(r, g, b) ((0xFF << 24) | (r << 16) | (g << 8) | b)
-#define GLT_RGB_R(rgb) ((rgb >> 16) & 0xFF)
-#define GLT_RGB_G(rgb) ((rgb >> 8) & 0xFF)
-#define GLT_RGB_B(rgb) (rgb & 0xFF)
-#define GLT_RGB_32_to_16(rgb) (((rgb & 0xFF) >> 3) | ((rgb & 0xFC00) >> 5) | ((rgb & 0xF80000) >> 8))
-#define GLT_RGB_16_to_32(rgb) (((rgb & 0x1F) << 3) | ((rgb & 0x7E0) << 5) | ((rgb & 0xF800) << 8))
+#define GLT_RGB(r, g, b) ((0xFF << 24) | (((unsigned int)(r)) << 16) | (((unsigned int)(g)) << 8) | ((unsigned int)(b)))
+#define GLT_RGB_R(rgb) ((((unsigned int)(rgb)) >> 16) & 0xFF)
+#define GLT_RGB_G(rgb) ((((unsigned int)(rgb)) >> 8) & 0xFF)
+#define GLT_RGB_B(rgb) (((unsigned int)(rgb)) & 0xFF)
+#define GLT_RGB_32_to_16(rgb) (((((unsigned int)(rgb)) & 0xFF) >> 3) | ((((unsigned int)(rgb)) & 0xFC00) >> 5) | ((((unsigned int)(rgb)) & 0xF80000) >> 8))
+#define GLT_RGB_16_to_32(rgb) (((((unsigned int)(rgb)) & 0x1F) << 3) | ((((unsigned int)(rgb)) & 0x7E0) << 5) | ((((unsigned int)(rgb)) & 0xF800) << 8))
 
 typedef struct _T_TIME
 {

--- a/core/src/cmd_target.cpp
+++ b/core/src/cmd_target.cpp
@@ -95,7 +95,7 @@ const GLT_MSG_ENTRY* c_cmd_target::FindMsgEntry(const GLT_MSG_ENTRY *pEntry,
 
 	while (MSG_CALLBACK_NULL != pEntry->callbackType)
 	{
-		if ( (msgType == pEntry->msgType) && (msgId == pEntry->msgId) && (void*)ctrlId == pEntry->pObject)
+		if ( (msgType == pEntry->msgType) && (msgId == pEntry->msgId) && (void*)(unsigned long)ctrlId == pEntry->pObject)
 		{
 			return pEntry;
 		}


### PR DESCRIPTION
in c++11 mode, we cannot do narrowing conversion in {}.