### PR TITLE
This fixes two incorrect function prototypes in headers.

### DIFF
--- a/core_include/display.h
+++ b/core_include/display.h
@@ -13,7 +13,7 @@ public:
 					unsigned int surface_width, unsigned int surface_height,
 					unsigned int color_bytes, unsigned int surface_cnt, EXTERNAL_GFX_OP* gfx_op = 0);
 	c_surface* alloc_surface(Z_ORDER_LEVEL max_zorder);
-	int merge_surface(c_surface* s1, c_surface* s2, int x0, int x1, int y0, int y2, int offset);
+	int merge_surface(c_surface* s0, c_surface* s1, int x0, int x1, int y0, int y2, int offset);
 	unsigned int get_width() { return m_width; }
 	unsigned int get_height() { return m_height; }
 

--- a/widgets_include/table.h
+++ b/widgets_include/table.h
@@ -22,7 +22,7 @@ public:
 	unsigned int get_col_num(){ return m_col_num;}
 	c_rect get_item_rect(int row, int col);
 protected:
-	void draw_item(int col, int row, const char* str, unsigned int color);
+	void draw_item(int row, int col, const char* str, unsigned int color);
 
 	unsigned int m_align_type;	
 	unsigned int m_row_num;


### PR DESCRIPTION
`display.h` lists the first two parameters as `s1` and `s2`, whereas the implementation lists them as `s0` and `s1`.
I changed the header to be `s0` and `s1`, seeing as the other parameters start at 0 too.

table.h lists the first two parameters as `col` then `row`, but the implementation lists them as `row` then `col`.
Judging by `set_item`, the order should be `row` then `col`, so I changed it to that.

Not essential fixes, but the row/col thing could be confusing for people who rely on tooltips.

Only tested on Windows, but it shouldn't affect other platforms.