### PR TITLE
modify to support displaying any color of the backgroud in c_label instead of being consistent with the m_parent c_wnd

### DIFF
--- a/workspace/widgets_include/label.h
+++ b/workspace/widgets_include/label.h
@@ -16,12 +16,13 @@ public:
 	virtual void on_paint()
 	{
 		c_rect rect;
+		unsigned int bg_color = m_bg_color ? m_bg_color \
+			: m_parent->get_bg_color();
 		get_screen_rect(rect);
-
 		if (m_str)
 		{
-			m_surface->fill_rect(rect.m_left, rect.m_top, rect.m_right, rect.m_bottom, m_parent->get_bg_color(), m_z_order);
-			c_word::draw_string_in_rect(m_surface, m_z_order, m_str, rect, m_font_type, m_font_color, m_parent->get_bg_color(), ALIGN_LEFT | ALIGN_VCENTER);
+			m_surface->fill_rect(rect.m_left, rect.m_top, rect.m_right, rect.m_bottom, bg_color, m_z_order);
+			c_word::draw_string_in_rect(m_surface, m_z_order, m_str, rect, m_font_type, m_font_color, bg_color, ALIGN_LEFT | ALIGN_VCENTER);
 		}
 	}
 protected:


### PR DESCRIPTION
modify to support displaying any color of the backgroud in c_label instead of being consistent with the m_parent c_wnd