### PR TITLE
add support for seting the align type of c_label

### DIFF
--- a/workspace/widgets_include/label.h
+++ b/workspace/widgets_include/label.h
@@ -13,6 +13,10 @@
 class c_label : public c_wnd
 {
 public:
+	void set_align_type(unsigned int align_type)
+	{
+		m_align_type = align_type;
+	}
 	virtual void on_paint()
 	{
 		c_rect rect;
@@ -22,16 +26,19 @@ public:
 		if (m_str)
 		{
 			m_surface->fill_rect(rect.m_left, rect.m_top, rect.m_right, rect.m_bottom, bg_color, m_z_order);
-			c_word::draw_string_in_rect(m_surface, m_z_order, m_str, rect, m_font_type, m_font_color, bg_color, ALIGN_LEFT | ALIGN_VCENTER);
+			c_word::draw_string_in_rect(m_surface, m_z_order, m_str, rect, m_font_type, m_font_color, bg_color, m_align_type);
 		}
 	}
 protected:
 	virtual void pre_create_wnd()
 	{
 		m_attr = ATTR_VISIBLE;
+		m_align_type = ALIGN_LEFT | ALIGN_VCENTER;
 		m_font_color = c_theme::get_color(COLOR_WND_FONT);
 		m_font_type = c_theme::get_font(FONT_DEFAULT);
 	}
+private:
+	unsigned int m_align_type;
 };
 
 #endif


### PR DESCRIPTION
When I try to change the c_label widget align type, i found it a little hard, so i add this func **set_align_type** with **c_label**.🙂