### PR TITLE
Add a judgment on the child's parent when show child

### DIFF
--- a/workspace/core_include/wnd.h
+++ b/workspace/core_include/wnd.h
@@ -142,7 +142,7 @@ public:
 			c_wnd* child = m_top_child;
 			if (0 != child)
 			{
-				while (child)
+				while (child && child->m_parent == this)
 				{
 					child->show_window();
 					child = child->m_next_sibling;


### PR DESCRIPTION
I found a bug when there are two dialogs. dialog A has wnd tree such as:
```
{ &s_dialog_enter_button,>--ID_DIALOG_ENTER6666_BUTTON,>"",>926, 30, 66, 66},
{ &gs_lamp_mode_buttons[LAMP_MODE_OFF_WORK],>---ID_BUTTON_LAMP_OFF_WORK,>---"",>655, 525, 350, 75},
{NULL, 0 , 0, 0, 0, 0, 0}
```
and another dialog B has wnd tree such as:
```
{ &s_dialog_enter_button,>--ID_DIALOG_ENTER6666_BUTTON,>"",>926, 30, 66, 66},
{NULL, 0 , 0, 0, 0, 0, 0}
```
When I show dialog B, I can find a button with  ID==ID_BUTTON_LAMP_OFF_WORK, after I check my code, I found there may has a BUG, so I do this ``Add a judgment on the child's parent when show child ``,